### PR TITLE
Refactor component util

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,14 @@
     "babel-preset-react-app"
   ],
   "plugins": [
-    "lodash"
+    [
+      "lodash",
+      {
+        "id": [
+          "lodash",
+          "recompose"
+        ]
+      }
+    ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1605,7 +1605,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
@@ -1614,8 +1613,7 @@
         "core-js": {
           "version": "2.5.4",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
-          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
-          "dev": true
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
         }
       }
     },
@@ -2123,6 +2121,11 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
+    },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "chardet": {
       "version": "0.4.2",
@@ -6103,6 +6106,11 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -13267,6 +13275,11 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz",
+      "integrity": "sha512-pbZOSMVVkvppW7XRn9fcHK5OgEDnYLwMva7P6TgS44/SN9uGGjfh3Z1c8tomO+y4IsHQ6Fsz2EGwmE7sMeNZgQ=="
+    },
     "react-popper": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.8.3.tgz",
@@ -13432,6 +13445,26 @@
         "resolve": "1.6.0"
       }
     },
+    "recompose": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.0.tgz",
+      "integrity": "sha512-hivr1EopLhzjchhv2Y7VcLA2H5NGztwV/qfYqmIAhTkNowNQ9PyXdfq9Q8QCa0TMrPM1NtStlUyi5I/p8XfUNQ==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "change-emitter": "0.1.6",
+        "fbjs": "0.8.16",
+        "hoist-non-react-statics": "2.5.0",
+        "react-lifecycles-compat": "3.0.2",
+        "symbol-observable": "1.2.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+        }
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -13487,8 +13520,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "reactstrap": "^5.0.0"
+    "reactstrap": "^5.0.0",
+    "recompose": "^0.27.0"
   },
   "devDependencies": {
     "@ridi/eslint-config": "^4.0.0",

--- a/src/components/Menu/CompositeMenu/index.js
+++ b/src/components/Menu/CompositeMenu/index.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { Alert, Button, ButtonGroup, Card } from 'reactstrap';
 import faUserCircle from '@fortawesome/fontawesome-free-solid/faUserCircle';
 import faSignOutAlt from '@fortawesome/fontawesome-free-solid/faSignOutAlt';
-import { getRestProps } from '../../../utils/component';
+import { getPassThroughProps } from '../../../utils/component';
 import { modularizeClassNames as cm } from '../../../utils/css';
 import FA from '../../FontAwesome';
 import MenuFilter from '../MenuFilter';
@@ -62,7 +62,7 @@ export default class Menu extends React.Component {
     const { className, items } = this.props;
 
     return (
-      <Card className={cm(className, 'composite_menu')} {...getRestProps(this)}>
+      <Card className={cm(className, 'composite_menu')} {...getPassThroughProps(this)}>
         <ButtonGroup className={cm('button_group')} size="sm">
           <Button tag="a" href="/me" color="link"><FA icon={faUserCircle} /> 개인정보 수정</Button>
           <Button tag="a" href="/logout" color="link"><FA icon={faSignOutAlt} /> 로그아웃</Button>

--- a/src/components/Menu/MenuFilter/index.js
+++ b/src/components/Menu/MenuFilter/index.js
@@ -4,7 +4,7 @@ import es6ClassBindAll from 'es6-class-bind-all';
 import _ from 'lodash';
 import { Button, Input } from 'reactstrap';
 import faTimes from '@fortawesome/fontawesome-free-solid/faTimes';
-import { getRestProps } from '../../../utils/component';
+import { getPassThroughProps } from '../../../utils/component';
 import { modularizeClassNames as cm } from '../../../utils/css';
 import FA from '../../FontAwesome';
 import MenuItem from '../MenuItem';
@@ -87,7 +87,7 @@ export default class MenuFilter extends React.Component {
     const { filterString } = this.state;
 
     return (
-      <div className={cm(className, 'menu_filter')} {...getRestProps(this)}>
+      <div className={cm(className, 'menu_filter')} {...getPassThroughProps(this)}>
         <Input
           bsSize="sm"
           type="search"

--- a/src/components/Menu/MenuItem/index.js
+++ b/src/components/Menu/MenuItem/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import es6ClassBindAll from 'es6-class-bind-all';
 import { NavItem, NavLink } from 'reactstrap';
-import { getRestProps } from '../../../utils/component';
+import { getPassThroughProps } from '../../../utils/component';
 import { modularizeClassNames as cm } from '../../../utils/css';
 
 const itemShape = {
@@ -45,7 +45,7 @@ export default class MenuItem extends React.PureComponent {
     return (
       <NavItem
         className={cm(className, 'item')}
-        {...getRestProps(this)}
+        {...getPassThroughProps(this)}
       >
         <NavLink
           className={cm('title')}

--- a/src/components/Menu/TreeMenu/index.js
+++ b/src/components/Menu/TreeMenu/index.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { Collapse, Nav } from 'reactstrap';
 import faCaretDown from '@fortawesome/fontawesome-free-solid/faCaretDown';
 import faCaretRight from '@fortawesome/fontawesome-free-solid/faCaretRight';
-import { getRestProps } from '../../../utils/component';
+import { getPassThroughProps } from '../../../utils/component';
 import { modularizeClassNames as cm } from '../../../utils/css';
 import FA from '../../FontAwesome';
 import MenuItem from '../MenuItem';
@@ -138,7 +138,7 @@ export default class TreeMenu extends React.Component {
       <Nav
         className={cm(className, 'tree_menu')}
         vertical
-        {...getRestProps(this)}
+        {...getPassThroughProps(this)}
       >
         {_.map(items, this.renderItemTree)}
       </Nav>

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { modularizeParentCss } from '../../higherOrderComponents';
+import { wrapWithCssModule } from '../../higherOrderComponents';
 import propsMapper from './propsMapper';
 import CompositeMenu from './CompositeMenu';
 
@@ -24,4 +24,4 @@ class Menu extends React.PureComponent {
   }
 }
 
-export default modularizeParentCss()(Menu);
+export default wrapWithCssModule()(Menu);

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { compose, mapProps, setPropTypes } from 'recompose';
+import * as recompose from 'recompose';
 import { wrapWithCssModule } from '../../higherOrderComponents';
 import propsMapper from './propsMapper';
 import CompositeMenu from './CompositeMenu';
@@ -14,8 +14,8 @@ const propTypes = {
   })),
 };
 
-export default compose(
+export default recompose.compose(
   wrapWithCssModule(),
-  setPropTypes(propTypes),
-  mapProps(propsMapper),
+  recompose.setPropTypes(propTypes),
+  recompose.mapProps(propsMapper),
 )(CompositeMenu);

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
+import { compose, mapProps } from 'recompose';
 import CompositeMenu from './CompositeMenu';
-import { mapProps, modularize } from '../../utils/component';
+import { modularize } from '../../utils/component';
 
 function buildItemTree(items) {
   const root = { id: 0, depth: -1, children: [] };
@@ -30,7 +31,7 @@ function buildItemTree(items) {
   return root;
 }
 
-export default _.flowRight([
+export default compose(
   modularize,
   mapProps(props => ({
     ...props,
@@ -46,4 +47,4 @@ export default _.flowRight([
       return buildItemTree(mappedItems).children;
     })(),
   })),
-])(CompositeMenu);
+)(CompositeMenu);

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,50 +1,9 @@
-import _ from 'lodash';
 import { compose, mapProps } from 'recompose';
-import CompositeMenu from './CompositeMenu';
 import { modularizeParentCss } from '../../higherOrderComponents';
-
-function buildItemTree(items) {
-  const root = { id: 0, depth: -1, children: [] };
-  const parents = [root];
-
-  _.forEach(items, (item, index) => {
-    const parent = (() => {
-      while (_.last(parents).depth >= item.depth) {
-        parents.pop();
-      }
-      return _.last(parents);
-    })();
-
-    const itemWithChildren = { ...item, children: [] };
-    parent.children.push(itemWithChildren);
-
-    if (item === _.last(items)) {
-      return;
-    }
-
-    if (items[index + 1].depth > item.depth) {
-      delete itemWithChildren.href;
-      parents.push(itemWithChildren);
-    }
-  });
-
-  return root;
-}
+import propsMapper from './propsMapper';
+import CompositeMenu from './CompositeMenu';
 
 export default compose(
   modularizeParentCss(),
-  mapProps(props => ({
-    ...props,
-    items: (() => {
-      const mappedItems = _.map(props.items, item => ({
-        id: item.id,
-        title: item.menu_title,
-        href: item.menu_url,
-        target: item.is_newtab ? '_blank' : undefined,
-        depth: item.menu_deep,
-      }));
-
-      return buildItemTree(mappedItems).children;
-    })(),
-  })),
+  mapProps(propsMapper),
 )(CompositeMenu);

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,9 +1,27 @@
-import { compose, mapProps } from 'recompose';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { modularizeParentCss } from '../../higherOrderComponents';
 import propsMapper from './propsMapper';
 import CompositeMenu from './CompositeMenu';
 
-export default compose(
-  modularizeParentCss(),
-  mapProps(propsMapper),
-)(CompositeMenu);
+class Menu extends React.PureComponent {
+  static propTypes = {
+    items: PropTypes.arrayOf(PropTypes.shape({
+      id: PropTypes.number,
+      menu_title: PropTypes.string,
+      menu_url: PropTypes.string,
+      is_newtab: PropTypes.bool,
+      menu_deep: PropTypes.number,
+    })),
+  };
+
+  static defaultProps = {
+    items: undefined,
+  };
+
+  render() {
+    return <CompositeMenu {...propsMapper(this.props)} />;
+  }
+}
+
+export default modularizeParentCss()(Menu);

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,27 +1,21 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import { compose, mapProps, setPropTypes } from 'recompose';
 import { wrapWithCssModule } from '../../higherOrderComponents';
 import propsMapper from './propsMapper';
 import CompositeMenu from './CompositeMenu';
 
-class Menu extends React.PureComponent {
-  static propTypes = {
-    items: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      menu_title: PropTypes.string,
-      menu_url: PropTypes.string,
-      is_newtab: PropTypes.bool,
-      menu_deep: PropTypes.number,
-    })),
-  };
+const propTypes = {
+  items: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number,
+    menu_title: PropTypes.string,
+    menu_url: PropTypes.string,
+    is_newtab: PropTypes.bool,
+    menu_deep: PropTypes.number,
+  })),
+};
 
-  static defaultProps = {
-    items: undefined,
-  };
-
-  render() {
-    return <CompositeMenu {...propsMapper(this.props)} />;
-  }
-}
-
-export default wrapWithCssModule()(Menu);
+export default compose(
+  wrapWithCssModule(),
+  setPropTypes(propTypes),
+  mapProps(propsMapper),
+)(CompositeMenu);

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { compose, mapProps } from 'recompose';
 import CompositeMenu from './CompositeMenu';
-import { modularize } from '../../utils/component';
+import { modularizeParentCss } from '../../higherOrderComponents';
 
 function buildItemTree(items) {
   const root = { id: 0, depth: -1, children: [] };
@@ -32,7 +32,7 @@ function buildItemTree(items) {
 }
 
 export default compose(
-  modularize,
+  modularizeParentCss(),
   mapProps(props => ({
     ...props,
     items: (() => {

--- a/src/components/Menu/propsMapper.js
+++ b/src/components/Menu/propsMapper.js
@@ -1,0 +1,53 @@
+import _ from 'lodash';
+
+function mapItemProperties(items) {
+  return _.map(items, item => ({
+    id: item.id,
+    title: item.menu_title,
+    href: item.menu_url,
+    target: item.is_newtab ? '_blank' : undefined,
+    depth: item.menu_deep,
+  }));
+}
+
+function mapItemsToItemTrees(items) {
+  const root = { id: 0, depth: -1, children: [] };
+  const parents = [root];
+
+  _.forEach(items, (item, index) => {
+    const parent = (() => {
+      while (_.last(parents).depth >= item.depth) {
+        parents.pop();
+      }
+      return _.last(parents);
+    })();
+
+    const itemWithChildren = { ...item, children: [] };
+    parent.children.push(itemWithChildren);
+
+    if (item === _.last(items)) {
+      return;
+    }
+
+    if (items[index + 1].depth > item.depth) {
+      delete itemWithChildren.href;
+      parents.push(itemWithChildren);
+    }
+  });
+
+  return root.children;
+}
+
+function mapItems(items) {
+  return _.flow([
+    mapItemProperties,
+    mapItemsToItemTrees,
+  ])(items);
+}
+
+export default function propsMapper(props) {
+  return {
+    ...props,
+    items: mapItems(props.items),
+  };
+}

--- a/src/higherOrderComponents/index.js
+++ b/src/higherOrderComponents/index.js
@@ -1,0 +1,5 @@
+/* eslint
+import/prefer-default-export: 0
+*/
+
+export { default as modularizeParentCss } from './modularizeParentCss';

--- a/src/higherOrderComponents/index.js
+++ b/src/higherOrderComponents/index.js
@@ -2,4 +2,4 @@
 import/prefer-default-export: 0
 */
 
-export { default as modularizeParentCss } from './modularizeParentCss';
+export { default as wrapWithCssModule } from './wrapWithCssModule';

--- a/src/higherOrderComponents/modularizeParentCss.js
+++ b/src/higherOrderComponents/modularizeParentCss.js
@@ -1,0 +1,17 @@
+/* eslint
+react/no-find-dom-node: 0
+*/
+
+import ReactDOM from 'react-dom';
+import { lifeCycle } from 'recompose';
+import { getGlobalCssModule } from '../utils/css';
+
+export default function modularizeParentCss() {
+  return lifeCycle({
+    componentDidMount() {
+      const { parentNode } = ReactDOM.findDOMNode(this);
+      const rootClassName = getGlobalCssModule().root;
+      parentNode.classList.add(rootClassName);
+    },
+  });
+}

--- a/src/higherOrderComponents/wrapWithCssModule.js
+++ b/src/higherOrderComponents/wrapWithCssModule.js
@@ -3,15 +3,26 @@ react/no-find-dom-node: 0
 */
 
 import ReactDOM from 'react-dom';
-import { lifeCycle } from 'recompose';
+import { lifeCycle, setDisplayName, wrapDisplayName } from 'recompose';
 import { getGlobalCssModule } from '../utils/css';
 
 export default function wrapWithCssModule() {
-  return lifeCycle({
-    componentDidMount() {
-      const { parentNode } = ReactDOM.findDOMNode(this);
-      const rootClassName = getGlobalCssModule().root;
-      parentNode.classList.add(rootClassName);
-    },
-  });
+  return (Component) => {
+    const enhance = lifeCycle({
+      componentDidMount() {
+        const { parentNode } = ReactDOM.findDOMNode(this);
+        const rootClassName = getGlobalCssModule().root;
+        parentNode.classList.add(rootClassName);
+      },
+    });
+
+    const WrappedComponent = enhance(Component);
+
+    if (process.env.NODE_ENV !== 'production') {
+      const wrappedName = wrapDisplayName(Component, 'wrapWithCssModule');
+      return setDisplayName(wrappedName)(WrappedComponent);
+    }
+
+    return WrappedComponent;
+  };
 }

--- a/src/higherOrderComponents/wrapWithCssModule.js
+++ b/src/higherOrderComponents/wrapWithCssModule.js
@@ -6,7 +6,7 @@ import ReactDOM from 'react-dom';
 import { lifeCycle } from 'recompose';
 import { getGlobalCssModule } from '../utils/css';
 
-export default function modularizeParentCss() {
+export default function wrapWithCssModule() {
   return lifeCycle({
     componentDidMount() {
       const { parentNode } = ReactDOM.findDOMNode(this);

--- a/src/utils/component.js
+++ b/src/utils/component.js
@@ -1,12 +1,8 @@
 /* eslint
-react/no-multi-comp: 0
-react/no-find-dom-node: 0
+import/prefer-default-export: 0
 */
 
-import React from 'react';
-import ReactDOM from 'react-dom';
 import _ from 'lodash';
-import { modularizeRootNode } from './css';
 
 export const getRestProps = (componentInstance) => {
   const {
@@ -17,19 +13,3 @@ export const getRestProps = (componentInstance) => {
   } = componentInstance;
   return _.omit(props, _.keys(propTypes));
 };
-
-export const modularize = Component => (
-  class extends React.PureComponent {
-    static get name() {
-      return `modularize(${Component.name})`;
-    }
-
-    componentDidMount() {
-      modularizeRootNode(ReactDOM.findDOMNode(this).parentNode);
-    }
-
-    render() {
-      return <Component {...this.props} />;
-    }
-  }
-);

--- a/src/utils/component.js
+++ b/src/utils/component.js
@@ -4,7 +4,7 @@ import/prefer-default-export: 0
 
 import _ from 'lodash';
 
-export const getRestProps = (componentInstance) => {
+export const getPassThroughProps = (componentInstance) => {
   const {
     props,
     constructor: {

--- a/src/utils/component.js
+++ b/src/utils/component.js
@@ -18,20 +18,6 @@ export const getRestProps = (componentInstance) => {
   return _.omit(props, _.keys(propTypes));
 };
 
-export const mapProps = mapper => (
-  Component => (
-    class extends React.PureComponent {
-      static get name() {
-        return `mapProps(${Component.name})`;
-      }
-
-      render() {
-        return <Component {...mapper(this.props)} />;
-      }
-    }
-  )
-);
-
 export const modularize = Component => (
   class extends React.PureComponent {
     static get name() {

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -13,7 +13,3 @@ export const setGlobalCssModule = (cssModule, rootModuleName) => {
 };
 
 export const modularizeClassNames = (...args) => Util.mapToCssModules(cn(...args));
-
-export const modularizeRootNode = (rootNode) => {
-  rootNode.classList.add(globalCssModule.root);
-};


### PR DESCRIPTION
According to the review on #19, gave names to ambiguous anonymous arrow functions and re-balanced abstraction levels.

For more clarity of data structure, prop types are newly defined explicitly in `Menu` component class. 

And [Higher-Order Components](https://reactjs.org/docs/higher-order-components.html) are extracted from `/utils/component`. For implementing HOCs, [recompose](https://github.com/acdlite/recompose) is used to leverage existing library.