### PR TITLE
Do not lock root scroll

### DIFF
--- a/src/components/Menu/CompositeMenu/index.js
+++ b/src/components/Menu/CompositeMenu/index.js
@@ -6,7 +6,7 @@ import faUserCircle from '@fortawesome/fontawesome-free-solid/faUserCircle';
 import faSignOutAlt from '@fortawesome/fontawesome-free-solid/faSignOutAlt';
 import faEllipsisV from '@fortawesome/fontawesome-free-solid/faEllipsisV';
 import { getPassThroughProps } from '../../../utils/component';
-import { lockRootScroll, modularizeClassNames as cm } from '../../../utils/css';
+import { modularizeClassNames as cm } from '../../../utils/css';
 import FilterableMenu from '../FilterableMenu';
 import FA from '../../FontAwesome';
 
@@ -47,12 +47,10 @@ export default class CompositeMenu extends React.Component {
 
   openMenu() {
     this.setState({ isOpen: true });
-    lockRootScroll(true);
   }
 
   closeMenu() {
     this.setState({ isOpen: false });
-    lockRootScroll(false);
   }
 
   toggleMenu() {

--- a/src/components/Menu/CompositeMenu/index.scss
+++ b/src/components/Menu/CompositeMenu/index.scss
@@ -5,11 +5,11 @@
   justify-content: flex-start;
   align-items: stretch;
   color: $white;
-  background-color: darken($dark, 10%);
+  background-color: rgba(darken($dark, 10%), .95);
 
   & .navigation_bar {
     flex-shrink: 0;
-    background-color: rgba($primary, .80);
+    background-color: darken($primary, 10%);
     align-items: stretch;
     padding: 0;
 

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,12 +1,4 @@
 html {
-  &.no_scroll {
-    overflow: hidden;
-
-    & body {
-      overflow: hidden;
-    }
-  }
-
   & body {
     margin: 3.5rem 0 0 0;
   }

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -13,8 +13,3 @@ export const setGlobalCssModule = (cssModule, rootModuleName) => {
 };
 
 export const modularizeClassNames = (...args) => Util.mapToCssModules(cn(...args));
-
-export const lockRootScroll = (lock) => {
-  const noScrollClassName = modularizeClassNames('no_scroll');
-  document.documentElement.classList.toggle(noScrollClassName, lock);
-};


### PR DESCRIPTION
In a small screen layout, body scroll is locked during menu is open in order to prevent unwanted scroll behavior while navigating menu items. But if the menu's height does not cover the entire screen, partial body's content will be visible but still scrolling is locked and it may confuse users.

Instead of locking scroll, we could **let scrolling be available by default**, and **make menu's background translucent** to show users whether the body is being scrolled.