### PR TITLE
Fix exposing CSS

### DIFF
--- a/src/higherOrderComponents/wrapWithCssModule.js
+++ b/src/higherOrderComponents/wrapWithCssModule.js
@@ -2,24 +2,19 @@
 react/no-find-dom-node: 0
 */
 
-import ReactDOM from 'react-dom';
-import { compose, lifeCycle, setDisplayName, setPropTypes, wrapDisplayName } from 'recompose';
+import React from 'react';
+import { setDisplayName, wrapDisplayName } from 'recompose';
 import { getGlobalCssModule } from '../utils/css';
 
 export default function wrapWithCssModule() {
   return (Component) => {
-    const enhance = compose(
-      setPropTypes(Component.propTypes),
-      lifeCycle({
-        componentDidMount() {
-          const { parentNode } = ReactDOM.findDOMNode(this);
-          const rootClassName = getGlobalCssModule().root;
-          parentNode.classList.add(rootClassName);
-        },
-      }),
+    const WrappedComponent = props => (
+      <div className={getGlobalCssModule().root}>
+        <Component {...props} />
+      </div>
     );
 
-    const WrappedComponent = enhance(Component);
+    WrappedComponent.propTypes = Component.propTypes;
 
     if (process.env.NODE_ENV !== 'production') {
       const wrappedName = wrapDisplayName(Component, 'wrapWithCssModule');

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,27 +1,25 @@
-html {
-  & body {
-    margin: 3.5rem 0 0 0;
+body {
+  margin: 3.5rem 0 0 0;
+}
+
+.menu {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  max-height: 100%;
+  z-index: 10000;
+}
+
+@media (min-width: 1200px) {
+  body {
+    margin: 0 0 0 17rem;
   }
 
-  & .menu {
-    position: fixed;
+  .menu {
     left: 0;
     top: 0;
-    right: 0;
-    max-height: 100%;
-    z-index: 10000;
-  }
-
-  @media (min-width: 1200px) {
-    & body {
-      margin: 0 0 0 17rem;
-    }
-
-    & .menu {
-      left: 0;
-      top: 0;
-      bottom: 0;
-      width: 17rem;
-    }
+    bottom: 0;
+    width: 17rem;
   }
 }


### PR DESCRIPTION
CSS has unintentionally applied to the siblings outside of library's component. This was because wrapping CSS class is attached to the parent DOM node of the component.